### PR TITLE
ts6.js: Better default kill message

### DIFF
--- a/ts6.js
+++ b/ts6.js
@@ -129,7 +129,7 @@ Soon.Server = function (options) {
          * @param {string=} message - Optional kill message.
          */
         this.kill = function(uid, message) {
-            selfserv.send('KILL ' + uid + ' :Killed (' + (message || 'Disconnected by services') + ')');
+            selfserv.send('KILL ' + uid + ' :Killed (' + (message || '<No reason given>') + ')');
         };
     };
     /**


### PR DESCRIPTION
Use '<No reason given>', because 'Disconnected by services' is only used
on freenode and it's silly.

'<No reason given>' is also the default kill message on charybdis-based servers.
