### PR TITLE
Add support for away-notify

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ Soon.Client = function (options) {
             if (self.accounts[line.nick]) {
                 line.account = self.accounts[line.nick];
             }
-            if (self.awaystatus[line.nick]) {
+            if (options.awaynotify && self.awaystatus[line.nick]) {
                 line.status = self.awaystatus[line.nick];
             }
         }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 var Soon = require('./index.js');
-var client = new Soon.Client({host: 'test.net', port: 6667, nick: 'testing', awaynotify: true});
+var client = new Soon.Client({host: 'test.net', port: 6667, nick: 'testing'});
 client.send = function() {};
+client.rl.emit('line', ':test.net CAP * LS :account-notify away-notify extended-join multi-prefix sasl tls');
+client.rl.emit('line', ':test.net CAP * ACK :account-notify away-notify extended-join');
 it('should emit registered on 001', function(done) {
     client.once('registered', done);
     client.rl.emit('line', ':test.net 001 testing :Testing\r\n');

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var Soon = require('./index.js');
-var client = new Soon.Client({host: 'test.net', port: 6667, nick: 'testing'});
+var client = new Soon.Client({host: 'test.net', port: 6667, nick: 'testing', awaynotify: true});
 client.send = function() {};
 it('should emit registered on 001', function(done) {
     client.once('registered', done);
@@ -182,4 +182,36 @@ it('should emit rpl_topic on 332', function(done) {
         done();
     });
     client.rl.emit('line', ':test.net 332 testing #testchan :test /topic');
+});
+it('should set away status to H when receiving a WHOX reply with the H status', function(done) {
+    client.once('privmsg', function(nick, channel, message, line) {
+        if (line.status != 'H') return done(new Error('failed to set H status'));
+        done();
+    });
+    client.rl.emit('line', ':test.net 354 testing here H*@ 0');
+    client.rl.emit('line', ':here!~test@testing/test PRIVMSG #testchan :testing is great!');
+});
+it('should set away status to G when receiving a WHOX reply with the G status', function(done) {
+    client.once('privmsg', function(nick, channel, message, line) {
+        if (line.status != 'G') return done(new Error('failed to set G status'));
+        done();
+    });
+    client.rl.emit('line', ':test.net 354 testing gone G*@ 0');
+    client.rl.emit('line', ':gone!~test@testing/test PRIVMSG #testchan :testing is great!');
+});
+it('should set away status to H when receiving AWAY without arguments', function(done) {
+    client.once('privmsg', function(nick, channel, message, line) {
+        if (line.status != 'H') return done(new Error('failed to set H status'));
+        done();
+    });
+    client.rl.emit('line', ':here!~test@testing/test AWAY');
+    client.rl.emit('line', ':here!~test@testing/test PRIVMSG #testchan :testing is great!');
+});
+it('should set away status to G when receiving AWAY with message', function(done) {
+    client.once('privmsg', function(nick, channel, message, line) {
+        if (line.status != 'G') return done(new Error('failed to set G status'));
+        done();
+    });
+    client.rl.emit('line', ':gone!~test@testing/test AWAY :gone');
+    client.rl.emit('line', ':gone!~test@testing/test PRIVMSG #testchan :testing is great!');
 });


### PR DESCRIPTION
This adds support for the [away-notify](https://github.com/ircv3/ircv3-specifications/blob/master/extensions/away-notify-3.1) client capability. Please do **not** merge this, there's still some work to do.
- [x] Add code to support away-notify
- [x] Test on a server with `away-notify` support
- [x] Write unit tests
